### PR TITLE
Fix feed url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   For friends of eggbug
 
 baseurl: /cohost-webring  # the subpath of your site, e.g. /blog
-url: https://ghp.beesbuzz.biz
+url: https://cwr.beesbuzz.biz
 repository: fluffy-critter/cohost-webring
 
 # END: You *can* customize the stuff below but you don't need to.


### PR DESCRIPTION
I tried to add the feed opml to my reader but noticed it was a 404. It seemed like it was just pointing at the wrong subdomain so I tried editing the url to cwr.beesbuzz.biz, and that worked.